### PR TITLE
added dtlocalreco to use default dt4DSegments

### DIFF
--- a/DQM/RPCMonitorModule/test/parallel/TimingTest.py
+++ b/DQM/RPCMonitorModule/test/parallel/TimingTest.py
@@ -1,5 +1,3 @@
-
-
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("OwnParticles")
 #process = cms.Process("RECO")
@@ -46,7 +44,7 @@ process.load("MuonTools.Configuration.StandAloneNoRpc_cff")
 process.load("RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cff")
 #timing producer
 process.load("STASkim.ProducerTest.standAloneTiming_cff")
-
+process.load("RecoLocalMuon.Configuration.RecoLocalMuon_cff")
 
 
 process.maxEvents = cms.untracked.PSet(
@@ -70,7 +68,7 @@ process.source = cms.Source("PoolSource",
 
 process.dTandCSCSegmentsinTracks = cms.EDProducer("DTandCSCSegmentsinTracks",
                                                   cscSegments = cms.untracked.InputTag("hltCscSegments"),
-                                                  dt4DSegments = cms.untracked.InputTag("hltDt4DSegments"),
+                                                  dt4DSegments = cms.untracked.InputTag("dt4DSegments"),
                                                   tracks = cms.untracked.InputTag("standAloneMuons",""),
                                                   MuonTimeMapLabel = cms.InputTag("staRegular", "combined"),
                                                   ptCutValue = cms.untracked.double(5),
@@ -112,6 +110,8 @@ process.museg = cms.EDAnalyzer("MuonSegmentEff",
     MuonCollectionLabel = cms.InputTag("standAloneMuons"),
     MuonTimeMapLabel = cms.InputTag("staRegular", "combined"),
     MuonRpcTimeMapLabel = cms.InputTag("staRegular", "rpc"),
+    MuonDtTimeMapLabel = cms.InputTag("staRegular", "dt"),
+    MuonCscTimeMapLabel = cms.InputTag("staRegular", "csc"),
     timingCutValue = cms.untracked.double(10.),
 
     incldt = cms.untracked.bool(True),
@@ -129,7 +129,7 @@ process.museg = cms.EDAnalyzer("MuonSegmentEff",
     rangestrips = cms.untracked.double(4.),
 
     cscSegments = cms.untracked.InputTag('hltCscSegments'),
-    dt4DSegments = cms.untracked.InputTag('hltDt4DSegments'),
+    dt4DSegments = cms.untracked.InputTag('dt4DSegments'),
     rpcRecHits = cms.untracked.InputTag("hltRpcRecHits"),
 
 
@@ -165,7 +165,7 @@ process.triggerFilter = cms.EDFilter('TriggerFilter',
  #                              fileName = cms.untracked.string("FedeTest.root"))
 
 
-process.p = cms.Path(process.normfilter*process.muonstandalonereco*process.standAloneTiming*process.dTandCSCSegmentsinTracks*process.rpcPointProducer*process.museg)
+process.p = cms.Path(process.normfilter*process.dtlocalreco*process.muonstandalonereco*process.standAloneTiming*process.dTandCSCSegmentsinTracks*process.rpcPointProducer*process.museg)
 #process.e = cms.EndPath(process.out)
 
 

--- a/DTandCSCSegmentsinTracks/DTandCSCSegmentsinTracks/python/dTandCSCSegmentsinTracks_cfi.py
+++ b/DTandCSCSegmentsinTracks/DTandCSCSegmentsinTracks/python/dTandCSCSegmentsinTracks_cfi.py
@@ -1,9 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 dTandCSCSegmentsinTracks = cms.EDProducer("DTandCSCSegmentsinTracks",
-                                          #cscSegments = cms.InputTag("hltCscSegments"),
-                                          #dt4DSegments = cms.InputTag("hltDt4DSegments"),
-                                          cscSegments = cms.InputTag('cscSegments'),
+                                          cscSegments = cms.InputTag("hltCscSegments"),
                                           dt4DSegments = cms.InputTag('dt4DSegments'),
                                           tracks = cms.InputTag("standAloneMuons","UpdatedAtVtx"),
                                           MuonTimeMapLabel = cms.InputTag("staUpdAtVtx", "combined"),

--- a/MuonTools/Configuration/python/HltMuonSegments_cff.py
+++ b/MuonTools/Configuration/python/HltMuonSegments_cff.py
@@ -1,14 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoMuon.Configuration.RecoMuon_cff import *
-
-MuonSeed.DTSegmentLabel = cms.InputTag('hltDt4DSegments')
+#replaced the hltDt4DSegments
+MuonSeed.DTSegmentLabel = cms.InputTag('dt4DSegments')
 MuonSeed.CSCSegmentLabel = cms.InputTag('hltCscSegments')
-ancientMuonSeed.DTRecSegmentLabel = cms.InputTag('hltDt4DSegments')
+ancientMuonSeed.DTRecSegmentLabel = cms.InputTag('dt4DSegments')
 ancientMuonSeed.CSCRecSegmentLabel = cms.InputTag('hltCscSegments')
 standAloneMuons.STATrajBuilderParameters.FilterParameters.RPCRecSegmentLabel = cms.InputTag("hltRpcRecHits")
 standAloneMuons.STATrajBuilderParameters.FilterParameters.CSCRecSegmentLabel = cms.InputTag("hltCscSegments")
-standAloneMuons.STATrajBuilderParameters.FilterParameters.DTRecSegmentLabel = cms.InputTag("hltDt4DSegments")
+standAloneMuons.STATrajBuilderParameters.FilterParameters.DTRecSegmentLabel = cms.InputTag("dt4DSegments")
 standAloneMuons.STATrajBuilderParameters.BWFilterParameters.CSCRecSegmentLabel = cms.InputTag("hltCscSegments")
-standAloneMuons.STATrajBuilderParameters.BWFilterParameters.DTRecSegmentLabel = cms.InputTag("hltDt4DSegments")
+standAloneMuons.STATrajBuilderParameters.BWFilterParameters.DTRecSegmentLabel = cms.InputTag("dt4DSegments")
 standAloneMuons.STATrajBuilderParameters.BWFilterParameters.RPCRecSegmentLabel = cms.InputTag("hltRpcRecHits")

--- a/STASkim/ProducerTest/python/standAloneTiming_cfi.py
+++ b/STASkim/ProducerTest/python/standAloneTiming_cfi.py
@@ -5,7 +5,7 @@ from RecoMuon.MuonIdentification.DTTimingExtractor_cfi import *
 from RecoMuon.MuonIdentification.CSCTimingExtractor_cfi import *
 from RecoMuon.TrackingTools.MuonSegmentMatcher_cff import *
 
-MuonSegmentMatcher_ = MuonSegmentMatcher.clone(MatchParameters = cms.PSet(DTsegments = cms.InputTag("hltDt4DSegments"),
+MuonSegmentMatcher_ = MuonSegmentMatcher.clone(MatchParameters = cms.PSet(DTsegments = cms.InputTag("dt4DSegments"),
                                                                           DTradius = cms.double(0.01),
                                                                           CSCsegments = cms.InputTag("hltCscSegments"),
                                                                           RPChits = cms.InputTag("hltRpcRecHits"),


### PR DESCRIPTION
The file to run is in DQM/RPCMonitorModule/test/parallel/TimingTest.py
but in this version some parameters of "musegeff" are missing, so it crashes as it is. 